### PR TITLE
Remove dependency on easy-install in db2jupyter.docker

### DIFF
--- a/Installation/db2jupyter.docker
+++ b/Installation/db2jupyter.docker
@@ -6,10 +6,10 @@
 #
 
 # Build image:
-# docker build -t db2jupyter -f db2jupyter.docker . 
+# docker build -t db2jupyter -f db2jupyter.docker .
 
 # Run image:
-# docker run --name db2jupyter -d -p 8888:8888 db2jupyter 
+# docker run --name db2jupyter -d -p 8888:8888 db2jupyter
 
 FROM continuumio/anaconda3
 
@@ -20,11 +20,11 @@ FROM continuumio/anaconda3
 
 RUN conda update -y conda && \
     conda install -y -c conda-forge ipywidgets qgrid && \
-    apt-get update && \ 
+    apt-get update && \
     apt-get install -y gcc  && \
-    easy_install ibm-db && \
+    conda install -y -c conda-forge ibm_db && \
     rm -rf /var/lib/apt/lists/*
- 
+
 # Create the directory for Jupyter defaults and insert the settings into the file
 # 1. Allow connection without a password
 # 2. True deletion of files (bypasses a bug in Jupyter)
@@ -39,7 +39,7 @@ RUN mkdir /root/.jupyter && \
 
 #
 # Command to start Jupyter in the container
-# Updated --ip='*' to --ip='0.0.0.0' 
+# Updated --ip='*' to --ip='0.0.0.0'
 #
 
 CMD jupyter notebook --NotebookApp.token= --notebook-dir=/opt/notebooks --ip='0.0.0.0' --port=8888 --no-browser --allow-root
@@ -47,5 +47,5 @@ CMD jupyter notebook --NotebookApp.token= --notebook-dir=/opt/notebooks --ip='0.
 ENV   DESCRIPTION="Db2 Jupyter Notebook" \
       VERSION="1.6" \
       BUILD_DATE="2019-10-22"
-      
+
 EXPOSE 8888


### PR DESCRIPTION
Takes a while to build, may be a more efficient way to do it.

This solves issue https://github.com/IBM/db2-jupyter/issues/7